### PR TITLE
Prevent default on enter

### DIFF
--- a/app/assets/javascripts/sign_up.js
+++ b/app/assets/javascripts/sign_up.js
@@ -38,6 +38,7 @@ var keyPressEnter = {
   name: function(){
     $('#user_name').on('keypress', function(e){
       if(e.keyCode == 13) {
+        e.preventDefault();
         $('#name-submit').click();
       }
     })
@@ -46,6 +47,7 @@ var keyPressEnter = {
   zipcode: function(){
     $('#user_zipcode').on('keypress', function(e){
       if (e.keyCode == 13){
+        e.preventDefault();
         $('#zipcode-submit').click();
       }
     })

--- a/spec/features/users_sign_up_spec.rb
+++ b/spec/features/users_sign_up_spec.rb
@@ -7,7 +7,7 @@ feature "User sign up" do
     @user = build(:user)
   end
 
-  xscenario "with valid information", js: true do
+  scenario "with valid information", js: true do
     fill_in "user[name]", with: @user.name
     click_button("name-submit")
     fill_in "user_zipcode", with: @user.zipcode


### PR DESCRIPTION
Small pull request. I was seeing our error messages when going through the form using `enter` to advance to the next field. Added a preventDefault on the name and zipcode enter keypress.

I also changed our pending test back into an actual test.
